### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ for you:
 ```ruby
 Faraday.new do |conn|
   conn.request :retry, max: 2, interval: 0.05,
-                       interval_randomness: 0.5, backoff_factor: 2
+                       interval_randomness: 0.5, backoff_factor: 2,
                        exceptions: [ Faraday::Error::ConnectionFailed ]
     conn.adapter :net_http_pooled
 end


### PR DESCRIPTION
Added missing comma on example.
